### PR TITLE
Refactor: Improve VPN script reliability and logging

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -1,46 +1,99 @@
 #!/bin/bash
 
-# Logging date format constant
-readonly LOG_DATE_FORMAT='%Y-%m-%d %H:%M:%S'
-# Regex indicating true-ish value
+readonly LOG_DATE_FORMAT_MANUAL='+%Y-%m-%d %H:%M:%S'
+readonly LOG_DATE_FORMAT_TS='%Y-%m-%d %H:%M:%S'
 readonly TRUE_REGEX='^(1|true|yes)$'
 
-# Function to log and exit on error. Argument should be the error message.
+# Internal helper to add timestamp to a message string.
+# Uses 'ts' command if available for precise timestamping of stdin,
+# otherwise falls back to using 'date' for a basic timestamp prefix.
+_log_timestamp() {
+    local message="${1}"
+    if command -v ts >/dev/null 2>&1; then
+        printf "%s\n" "${message}" | ts "${LOG_DATE_FORMAT_TS}"
+    else
+        printf "[%s] %s\n" "$(date "${LOG_DATE_FORMAT_MANUAL}")" "${message}"
+    fi
+}
+
 log_error_and_exit() {
-    local -r message="$1"
-    echo "[ERROR] ${message}" | ts "${LOG_DATE_FORMAT}"
-    sleep 10
-    exit 1
+    local message="${1}"
+    local exit_code="${2:-1}"
+
+    _log_timestamp "[ERROR] ${message}" >&2
+
+    sleep 5
+
+    exit "${exit_code}"
 }
 
-# Function to log a warning. Argument should be the warning message.
 log_warning() {
-    local -r message="$1"
-    echo "[WARNING] ${message}" | ts "${LOG_DATE_FORMAT}"
+    local message="${1}"
+    
+    _log_timestamp "[WARNING] ${message}" >&2
 }
 
-# Function to log an information message. Argument should be the message.
 log_info() {
-    local -r message="$1"
-    echo "[INFO] ${message}" | ts "${LOG_DATE_FORMAT}"
+    local message="${1}"
+
+    _log_timestamp "[INFO] ${message}"
 }
 
-# Function to convert a file to Unix format
+log_debug() {
+    local message="${1}"
+
+    if [[ "${DEBUG,,}" =~ ${TRUE_REGEX} ]]; then
+         _log_timestamp "[DEBUG] ${message}"
+    fi
+}
+
 convert_to_unix() {
     local file="${1}"
-    dos2unix "${file}" 1>/dev/null
+
+    if [[ ! -f "${file}" ]]; then
+        log_warning "Cannot convert non-existent file to Unix format: ${file}"
+        return 1
+    fi
+
+    if command -v dos2unix >/dev/null 2>&1; then
+        log_debug "Attempting dos2unix conversion for: ${file}"
+        # redirect stdout/stderr of dos2unix to avoid polluting logs unless DEBUG is on
+        if [[ "${DEBUG,,}" =~ ${TRUE_REGEX} ]]; then
+             if dos2unix "${file}"; then
+                log_debug "Successfully converted ${file} to Unix line endings."
+                return 0
+             else
+                 log_warning "dos2unix command failed for file: ${file}. Check file permissions or content."
+                return 1
+             fi
+        else
+            if dos2unix "${file}" >/dev/null 2>&1; then
+                return 0
+            else
+                log_warning "dos2unix command failed for file: ${file}. Check file permissions or content."
+                return 1
+            fi
+        fi
+    else
+        log_warning "'dos2unix' command not found. Skipping line ending conversion for ${file}."
+        return 0
+    fi
 }
 
-validate_key_value() {
-    local key="${1}"
+validate_value() {
+    local description="${1}"
     local value="${2}"
-    local config_file="${3}"
+    local details="${3:-}"
 
-    if [[ -n "${value}" ]]; then
-        log_info "${key} defined as '${value}'"
-    elif [[ -n "${config_file}" ]]; then
-        log_error_and_exit "${key} not found in ${config_file}, exiting..."
+    if [[ -z "${value}" ]]; then
+        local error_message
+        error_message=$(printf "'%s' is empty or not set." "${description}")
+        if [[ -n "${details}" ]]; then
+            error_message="${error_message} ${details}"
+        fi
+        log_error_and_exit "${error_message}"
     else
-        log_error_and_exit "${key} not defined, exiting..."
+        log_debug "'${description}' validated successfully."
+        : # bash requires a command here, ':' is a no-op
     fi
 }

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -25,21 +25,21 @@ if [[ "${VPN_ENABLED}" =~ ${TRUE_REGEX} ]]; then
     add_credentials_to_openvpn_config "${VPN_TYPE}" "${VPN_CONFIG}" "${VPN_USERNAME}" "${VPN_PASSWORD}"
 
     convert_to_unix "${VPN_CONFIG}"
-    vpn_remote_line=$(extract_vpn_remote_address "${VPN_TYPE}" "${VPN_CONFIG}")
+    vpn_remote_line=$(extract_vpn_remote_address_line "${VPN_TYPE}" "${VPN_CONFIG}")
 
-    validate_key_value "VPN remote line" "${vpn_remote_line}" "${VPN_CONFIG}"
+    validate_value "VPN remote line" "${vpn_remote_line}" "${VPN_CONFIG}"
 
     export VPN_REMOTE="$(configure_remote "${VPN_TYPE}" "${vpn_remote_line}")"
-    validate_key_value "VPN_REMOTE" "${VPN_REMOTE}" "${VPN_CONFIG}"
+    validate_value "VPN_REMOTE" "${VPN_REMOTE}" "${VPN_CONFIG}"
 
     export VPN_PORT="$(configure_port "${VPN_TYPE}" "${vpn_remote_line}")"
-    validate_key_value "VPN_PORT" "${VPN_PORT}" "${VPN_CONFIG}"
+    validate_value "VPN_PORT" "${VPN_PORT}" "${VPN_CONFIG}"
 
-    export VPN_PROTOCOL="$(configure_protocol "${VPN_TYPE}")"
-    validate_key_value "VPN_PROTOCOL" "${VPN_PROTOCOL}" "${VPN_CONFIG}"
+    export VPN_PROTOCOL="$(configure_protocol "${VPN_TYPE}" "${VPN_CONFIG}")"
+    validate_value "VPN_PROTOCOL" "${VPN_PROTOCOL}" "${VPN_CONFIG}"
 
     export VPN_DEVICE_TYPE="$(configure_device_type "${VPN_TYPE}" "${VPN_CONFIG}")"
-    validate_key_value "VPN_DEVICE_TYPE" "${VPN_DEVICE_TYPE}" "${VPN_CONFIG}"
+    validate_value "VPN_DEVICE_TYPE" "${VPN_DEVICE_TYPE}" "${VPN_CONFIG}"
 
     configure_env_vars "LAN_NETWORK" ""
     configure_env_vars "NAME_SERVERS" "1.1.1.1,8.8.8.8,1.0.0.1,8.8.4.4"

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -1,49 +1,147 @@
 #!/bin/bash
 
 readonly SLEEP_DELAY='0.5'
+readonly PROCESS_CHECK_DELAY='2'
 
 start_open_vpn() {
-    local vpn_config_path="${1}"
-    local vpn_config_dir=$(dirname "${vpn_config_path}")
-    local vpn_config_file=$(basename "${vpn_config_path}")
+    local -r vpn_config_path="${1}"
+    local -r vpn_config_dir=$(dirname "${vpn_config_path}")
+    local -r vpn_config_file=$(basename "${vpn_config_path}")
 
-    log_info "Starting OpenVPN from directory ${vpn_config_dir}..."
+    local -r openvpn_log_file="/config/openvpn/openvpn.log" # stdout
+    local -r openvpn_stderr_tmp="/tmp/openvpn_stderr.log"   # stderr
+
+    local openvpn_pid
+
+    log_info "Attempting to start OpenVPN process in background..."
+    log_info "Using config: ${vpn_config_path}"
+    log_info "OpenVPN detailed logs will be written to: ${openvpn_log_file}"
+
+    if ! mkdir -p "$(dirname "${openvpn_log_file}")"; then
+        log_warning "Could not create log directory $(dirname "${openvpn_log_file}"). Logging might fail."
+    fi
+
+    touch "${openvpn_log_file}" || log_warning "Could not touch log file ${openvpn_log_file}"
     
-    cd "${vpn_config_dir}"
+    rm -f "${openvpn_stderr_tmp}"
     
-    exec openvpn --pull-filter ignore route-ipv6 --pull-filter ignore ifconfig-ipv6 --config "${vpn_config_file}" &
+    # change to the directory containing the config file so relative paths (certs, etc.) work
+    cd "${vpn_config_dir}" || { log_warning "Failed to change directory to ${vpn_config_dir}. Relative paths in config might fail."; return 1; }
+    
+    openvpn --pull-filter ignore route-ipv6 --pull-filter ignore ifconfig-ipv6 --config "${vpn_config_file}" 1>> "${openvpn_log_file}" 2> "${openvpn_stderr_tmp}" &
+    openvpn_pid=$!
+
+    if [[ -z "${openvpn_pid}" ]]; then
+        log_warning "Failed to get PID for OpenVPN process launch."
+        # check if the temporary stderr file captured anything during the failed launch
+        if [[ -s "${openvpn_stderr_tmp}" ]]; then
+             log_warning "Error output captured during launch attempt:"
+             cat "${openvpn_stderr_tmp}" | while IFS= read -r line; do log_warning "  | ${line}"; done
+             cat "${openvpn_stderr_tmp}" >> "${openvpn_log_file}"
+             rm -f "${openvpn_stderr_tmp}"
+        else
+            log_warning "No specific error output captured."
+        fi
+        cd - > /dev/null
+        return 1
+    fi
+
+
+    log_info "OpenVPN process launched with PID ${openvpn_pid}. Waiting ${PROCESS_CHECK_DELAY}s to check status..."
+    sleep "${PROCESS_CHECK_DELAY}"
+
+    if kill -0 "${openvpn_pid}" 2>/dev/null; then
+        log_info "OpenVPN process (PID ${openvpn_pid}) appears to be running successfully."
+        log_info "For detailed OpenVPN status, check the log file: ${openvpn_log_file}"
+        if [[ -f "${openvpn_stderr_tmp}" ]]; then
+            cat "${openvpn_stderr_tmp}" >> "${openvpn_log_file}"
+            rm -f "${openvpn_stderr_tmp}"
+        fi
+        cd - > /dev/null
+        return 0
+    else
+        log_warning "OpenVPN process (PID ${openvpn_pid}) failed to start correctly or exited prematurely."
+        if [[ -s "${openvpn_stderr_tmp}" ]]; then
+             log_warning "Error output captured from OpenVPN:"
+             cat "${openvpn_stderr_tmp}" | while IFS= read -r line; do log_warning "  | ${line}"; done
+             cat "${openvpn_stderr_tmp}" >> "${openvpn_log_file}"
+             rm -f "${openvpn_stderr_tmp}"
+        else
+             log_warning "No specific error output was captured in temporary stderr file."
+             log_warning "Check the main OpenVPN log file for details: ${openvpn_log_file}"
+        fi
+        cd - > /dev/null
+        return 1
+    fi
 }
 
 start_wire_guard() {
-    local vpn_config_path="${1}"
-
-    log_info "Starting WireGuard..."
-
+    local -r vpn_config_path="${1}"
     local conf_name
-    conf_name=$(basename -s .conf "${vpn_config_path}")
 
-    if (($(ip link | grep -c "${conf_name}") > 0)); then
-        wg-quick down "${vpn_config_path}" || log_info "WireGuard is down already"
-        sleep "${SLEEP_DELAY}"
+    # Extract config name (e.g., wg0) from the path wg0.conf -> wg0
+    conf_name=$(basename -s .conf "${vpn_config_path}")
+    if [[ -z "${conf_name}" ]]; then
+        log_warning "Could not determine WireGuard interface name from path ${vpn_config_path}."
+        return 1
     fi
-    wg-quick up "${vpn_config_path}"
+
+    log_info "Attempting to start WireGuard interface ${conf_name}..."
+    log_info "Using config: ${vpn_config_path}"
+
+    # check if the interface exists and try to bring it down first
+    # wg-quick down is idempotent, but checking first avoids unnecessary commands/logs
+    if ip link show "${conf_name}" > /dev/null 2>&1; then
+        log_info "Interface ${conf_name} exists, attempting wg-quick down..."
+        # failure here is not critical, might already be down or have issues
+        wg-quick down "${vpn_config_path}" || log_info "wg-quick down exited non-zero (interface might be down or config issues)."
+    else
+        log_info "Interface ${conf_name} does not exist yet."
+    fi
+
+    log_info "Running wg-quick up ${conf_name}..."
+    if wg-quick up "${vpn_config_path}"; then
+        log_info "WireGuard interface ${conf_name} started successfully via wg-quick."
+        return 0
+    else
+        local exit_code=$?
+        log_warning "wg-quick up for ${conf_name} failed with exit code ${exit_code}."
+        log_warning "Check WireGuard/system logs (e.g., 'journalctl -u wg-quick@${conf_name}' on host if applicable, or container logs)."
+        return 1
+    fi
 }
 
 start_vpn() {
-    local vpn_type="${1}"
-    local vpn_config_path="${2}"
+    local -r vpn_type="${1}"
+    local -r vpn_config_path="${2}"
+    local vpn_started_successfully=false
+
+    log_info "Initiating VPN startup sequence for type: ${vpn_type}"
 
     case "${vpn_type}" in
     openvpn)
-        start_open_vpn "${vpn_config_path}"
+        if start_open_vpn "${vpn_config_path}"; then
+            vpn_started_successfully=true
+        fi
         ;;
     wireguard)
-        start_wire_guard "${vpn_config_path}"
+        if start_wire_guard "${vpn_config_path}"; then
+            vpn_started_successfully=true
+        fi
         ;;
     *)
-        log_error_and_exit "Invalid VPN_TYPE: ${VPN_TYPE}"
+        log_error_and_exit "Invalid VPN_TYPE '${vpn_type}' passed to start_vpn function."
         ;;
     esac
+
+    if [[ "${vpn_started_successfully}" == "true" ]]; then
+        log_info "VPN startup sequence appears successful for ${vpn_type}."
+        # allow some time for the tunnel interface to potentially appear/stabilize before iptables script runs
+        log_info "Waiting briefly for tunnel interface..."
+        sleep 2
+    else
+        log_error_and_exit "VPN (${vpn_type}) failed to start correctly. Cannot launch qBittorrent securely. Check previous logs."
+    fi
 }
 
 display_vpn_disabled_warning() {
@@ -55,15 +153,16 @@ display_vpn_disabled_warning() {
 }
 
 start_qbittorrent() {
-    local vpn_enabled="${1}"
+    local -r vpn_enabled="${1}"
 
     if [[ "${vpn_enabled}" =~ ${TRUE_REGEX} ]]; then
-        log_info "Starting qBitTorrent with VPN enabled..."
-
+        log_info "Executing iptables script to configure firewall and start qBittorrent..."
         exec /bin/bash /etc/qbittorrent/iptables.sh
     else
-        log_info "Starting qBitTorrent without VPN..."
-
+        log_info "Executing standard qBittorrent start script (VPN disabled)..."
         exec /bin/bash /etc/qbittorrent/start.sh
     fi
+
+    # If exec fails for some reason (e.g., script not found/executable), log error.
+    log_error_and_exit "Failed to execute the target qBittorrent start script. Path: ${target_script}"
 }


### PR DESCRIPTION
This PR refactors VPN configuration and startup scripts (`vpn-config.sh`, `constants.sh`, `start-services.sh`) for increased robustness, better logging, and improved compatibility.

**Key Improvements:**

*   **Robust OpenVPN Config Handling:** Replaced fragile `sed` commands with a reliable line-by-line processing method for `auth-user-pass`.
*   **Improved Compatibility:** Fixed `grep -P` lookbehind errors on Alpine by switching to `grep -E | sed`.
*   **Reliable VPN Startup:**
    *   Verified OpenVPN process starts correctly (`kill -0`).
    *   Redirected OpenVPN logs to `/config/openvpn/openvpn.log`; startup errors (stderr) are logged directly only if OpenVPN fails immediately.
    *   **Crucially, the container now exits if VPN is enabled but fails to start**, preventing unprotected operation.
*   **Enhanced Logging:** Added `DEBUG` level, sent WARNING/ERROR logs to `stderr`, and added a fallback for `ts` timestamping.